### PR TITLE
Revert "Revert "Jump search""

### DIFF
--- a/lib/algorithms/searches/jump_search.dart
+++ b/lib/algorithms/searches/jump_search.dart
@@ -1,0 +1,39 @@
+import 'dart:math';
+
+/// Searches [list] for [find] using the jump search method
+/// This algorithm assumes that [list] is in ascending order
+///
+/// Algorithm searches by jumping items in the list until items are greater than [find]
+/// Then [list] at previous jump point is searched linearly until [find] is found
+/// -1 is returned if [find] not in [list], returns index value of [find] if present in [list]
+
+int jumpSearch<J extends Comparable>(List<J> list, J find) {
+  var numItems = list.length;
+
+  if (numItems == 0) {
+    return -1;
+  }
+
+  var index = 0;
+  var jump = sqrt(numItems).floor();
+
+  // Algorithm searches by jumping items in the list until items are greater than find
+  while (list[min(jump, numItems) - 1].compareTo(find) < 0) {
+    index = jump;
+    jump += jump;
+    if (index >= numItems) {
+      return -1;
+    }
+  }
+  // Then at previous jump point is searched linearly until find is found
+  while (list[index].compareTo(find) < 0) {
+    index++;
+    if (index == min(jump, numItems)) {
+      return -1;
+    }
+  }
+  if (list[index] == find) {
+    return index;
+  }
+  return -1;
+}

--- a/test/algorithms/searches/jump_search_test.dart
+++ b/test/algorithms/searches/jump_search_test.dart
@@ -1,0 +1,49 @@
+import 'package:DDSA/algorithms/searches/jump_search.dart';
+import 'package:test/test.dart';
+
+void main() {
+  // Empty list case
+  // single
+  // multiple even
+  // multiple odd
+
+  group('JumpSearch:', () {
+    group('When searching a list', () {
+      final notPresentTest = <T extends Comparable>(List<T> list, T find) {
+        group('and the item isn\'t present', () {
+          test('then returns -1.', () {
+            expect(jumpSearch(list, find), equals(-1));
+          });
+        });
+      };
+
+      final presentTest =
+          <T extends Comparable>(List<T> list, T find, int expectedIndex) {
+        group('and the item is present', () {
+          test('then returns the index of that item.', () {
+            expect(jumpSearch(list, find), equals(expectedIndex));
+          });
+        });
+      };
+
+      group('that is empty', () {
+        notPresentTest<int>([], 4);
+      });
+      group('that has a single item', () {
+        final testList = [1];
+        notPresentTest(testList, 3);
+        presentTest(testList, 1, 0);
+      });
+      group('that has an even number of items', () {
+        final testList = [1, 2, 3, 4, 5, 6];
+        notPresentTest(testList, 7);
+        presentTest(testList, 6, 5);
+      });
+      group('that has an odd number of items', () {
+        final testList = [1, 2, 3, 4, 5];
+        notPresentTest(testList, 6);
+        presentTest(testList, 3, 2);
+      });
+    });
+  });
+}

--- a/test/ddsa_test.dart
+++ b/test/ddsa_test.dart
@@ -4,11 +4,13 @@ import 'design_patterns/chain_of_responsibility/chain_of_responsibility_test.dar
     as chain_of_responsibility;
 import 'algorithms/searches/linear_search_test.dart' as linear_search;
 import 'algorithms/searches/binary_search_test.dart' as binary_search;
+import 'algorithms/searches/jump_search_test.dart' as jump_search;
 
 void main() {
   sorting.main();
   chain_of_responsibility.main();
   linear_search.main();
   binary_search.main();
+  jump_search.main();
   adapter_pattern.main();
 }


### PR DESCRIPTION
Reverts commonCereal/DDSA#19

Data Structure / Algorithm

    Jump search algorithm

Solution / Explanation of Implementation.

    Searches a list for a target value using the jump search method
    This algorithm assumes that the list is in ascending order
    Algorithm searches by jumping items in the list until items are greater than the target value
    Then the list is searched linearly beginning at the previous jump point until the target value is found
    -1 is returned if target value is not in the list, returns index value of the target value if present in the list

Semver Check

[ ] Major - Backwards Incompatible change on the API (includes removals)

[X] Minor - Adds or deprecates part of the API.

[ ] Patch - Doesn't effect API

Tag Reviewer(s)

@commonCereal